### PR TITLE
Fix incorrect Visit and Dashboard links in Dashboard > My Networks.

### DIFF
--- a/src/wpmn-admin.php
+++ b/src/wpmn-admin.php
@@ -788,7 +788,7 @@ class WPMN_Admin {
 			$my_networks = user_has_networks();
 			foreach( $my_networks as $key => $network_id ) {
 				$my_networks[$key] = $wpdb->get_row( $wpdb->prepare(
-					'SELECT s.*, sm.meta_value as site_name, b.blog_id FROM ' . $wpdb->site . ' s LEFT JOIN ' . $wpdb->sitemeta . ' as sm ON sm.site_id = s.id AND sm.meta_key = %s LEFT JOIN ' . $wpdb->blogs . ' b ON s.id = b.site_id WHERE s.id = %d',
+					'SELECT s.*, sm.meta_value as site_name, b.blog_id FROM ' . $wpdb->site . ' s LEFT JOIN ' . $wpdb->sitemeta . ' as sm ON sm.site_id = s.id AND sm.meta_key = %s LEFT JOIN ' . $wpdb->blogs . ' b ON s.id = b.site_id AND b.path = s.path WHERE s.id = %d',
 					'site_name',
 					$network_id
 				) );


### PR DESCRIPTION
This problem happens when the first site in wp_blogs (left joined table) is not the root site, so the URLs are generated for the first matched site row rather than the root site.

Ideally, we would fix this using `network_home_url` and `network_admin_url` after calling `switch_to_network`, but this would add a lot of extra queries in a WP installation with lots of networks. On the positive side, it would make the SQL query very simple (i.e. without the LEFT JOINS).