### PR TITLE
Ensure rewrite rules are re-generated after move

### DIFF
--- a/src/wpmn-functions.php
+++ b/src/wpmn-functions.php
@@ -563,6 +563,9 @@ function move_site( $site_id, $new_network_id ) {
 		update_blog_option( $site->blog_id, $option_name, $new_value );
 	}
 
+	// Delete rewrite rules for site at old URL
+	delete_blog_option( $site_id, 'rewrite_rules' );
+
 	do_action( 'move_site', $site_id, $old_network_id, $new_network_id );
 }
 


### PR DESCRIPTION
We recently switched from Networks to WordPress to WP Multi Network at BU. One thing that we lost in the switch was rewrite rule flushing post-site move. This lead to 404's for custom post types after a site was launched from our staging domain to production.

See https://github.com/ddean4040/Networks-for-WordPress/blob/0f2c46889621e6896eefb2c82e7ead68bdfda45f/networks-functions.php#L448-L449 and https://wordpress.org/support/topic/delete-rewrite_rules-on-site-move.