### PR TITLE
Fix for 'public' keyword in admin Javascript

### DIFF
--- a/includes/class-wp-ms-networks-admin.php
+++ b/includes/class-wp-ms-networks-admin.php
@@ -74,7 +74,7 @@ class WPMN_Admin {
 
 			});
 
-			public function move( from, to ) {
+			function move( from, to ) {
 				jQuery( '#' + from ).children( 'option:selected' ).each( function() {
 					jQuery( '#' + to ).append( jQuery( this ).clone() );
 					jQuery( this ).remove();


### PR DESCRIPTION
The "public" keyword in the admin Javascript prevents assigning sites in the admin interface