### PR TITLE
Skip missing options on move

### DIFF
--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -581,7 +581,12 @@ function move_site( $site_id, $new_network_id ) {
 
 	// Update all site options
 	foreach ( network_options_list() as $option_name ) {
-		$option    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$options_table} WHERE option_name = %s", $option_name ) );
+		$option = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$options_table} WHERE option_name = %s", $option_name ) );
+		if ( empty( $option ) ) {
+			// No value, so no need to update it
+			continue;
+		}
+
 		$new_value = str_replace( $old_domain, $new_domain, $option->option_value );
 		update_blog_option( $site->blog_id, $option_name, $new_value );
 	}


### PR DESCRIPTION
If an option isn't set for a network, there's no need to attempt a string replace on the URLs. This causes a warning otherwise for options like `fileupload_url`, which as far as I can see, is never actually set by WP, but is included in `network_options_list`