### PR TITLE
Fix errors on creating new network

### DIFF
--- a/includes/classes/class-wp-ms-networks-admin.php
+++ b/includes/classes/class-wp-ms-networks-admin.php
@@ -716,13 +716,13 @@ class WPMN_Admin {
 		}
 
 		// Add the network
-		$result = add_network(
-			$network_domain,
-			$network_path,
-			$site_name,
-			$clone,
-			$options_to_clone
-		);
+		$result = add_network( array(
+			'domain' => $network_domain,
+			'path' => $network_path,
+			'site_name' => $site_name,
+			'clone_network' => $clone,
+			'options_to_clone' => $options_to_clone
+		) );
 
 		// Update title
 		if ( ! empty( $result ) && ! is_wp_error( $result ) ) {

--- a/includes/classes/class-wp-ms-networks-cli.php
+++ b/includes/classes/class-wp-ms-networks-cli.php
@@ -51,7 +51,13 @@ class WPMN_Command extends WP_CLI_Command {
 			}
 		}
 
-		$network_id = add_network( $domain, $path, $assoc_args['site_name'], $clone_network, $options_to_clone );
+		$network_id = add_network( array(
+			'domain' => $domain,
+			'path' => $path,
+			'site_name' => $assoc_args['site_name'],
+			'clone_network' => $clone_network,
+			'options_to_clone' => $options_to_clone
+		) );
 
 		if ( is_wp_error( $network_id ) ) {
 			WP_CLI::error( $network_id );

--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -276,7 +276,7 @@ function add_network( $args = array() ) {
 
 	// If no options, fallback on defaults
 	if ( empty( $r['options_to_clone'] ) ) {
-		$options_to_clone = array_keys( network_options_to_copy() );
+		$r['options_to_clone'] = array_keys( network_options_to_copy() );
 	}
 
 	// Check for existing network
@@ -372,18 +372,18 @@ function add_network( $args = array() ) {
 	if ( ! empty( $r['clone_network'] ) && wp_get_network( $r['clone_network'] ) ) {
 
 		$options_cache = array();
-		$clone_network = (int) $clone_network;
+		$clone_network = (int) $r['clone_network'];
 
 		switch_to_network( $clone_network );
 
-		foreach ( $options_to_clone as $option ) {
+		foreach ( $r['options_to_clone'] as $option ) {
 			$options_cache[$option] = get_site_option( $option );
 		}
 
 		restore_current_network();
 		switch_to_network( $new_network_id );
 
-		foreach( $options_to_clone as $option ) {
+		foreach( $r['options_to_clone'] as $option ) {
 			if ( isset( $options_cache[$option] ) ) {
 
 				// Fix for bug that prevents writing the ms_files_rewriting


### PR DESCRIPTION
The changes introduced in the commits on #49 have broken the process of creating new network. New networks *are* created - but without a user being given Network Admin status, which makes the new networks non-functional.

This PR solves two related issues:

* fixes the "undefined variable" notice for `$clone_network` and `$options_to_clone`, thus fixing the creation of the new Network Admin
* fixes the "`add_network()` was called with a deprecated argument" notice